### PR TITLE
File watcher

### DIFF
--- a/src/datafileparser.cpp
+++ b/src/datafileparser.cpp
@@ -9,7 +9,7 @@
 DataFileParser::DataFileParser() :
     _pFileWatcher(new QFileSystemWatcher())
 {
-    connect(_pFileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(fileChange(QString)));
+    connect(_pFileWatcher, SIGNAL(fileChanged(QString)), this, SLOT(fileDataChange(QString)));
 }
 
 DataFileParser::~DataFileParser()
@@ -63,7 +63,10 @@ bool DataFileParser::loadDataFile()
             _pFileWatcher->removePaths(_pFileWatcher->directories());
         }
 
-        _pFileWatcher->addPath(_parseSettings.getPath());
+        if(!_pFileWatcher->addPath(_parseSettings.getPath()))
+        {
+            emit addFileWatchFailed(_parseSettings.getPath());
+        }
     }
     else
     {
@@ -74,11 +77,11 @@ bool DataFileParser::loadDataFile()
     return bRet;
 }
 
-void DataFileParser::fileChange(QString path)
+void DataFileParser::fileDataChange(QString path)
 {
-    if(path == _parseSettings.getPath())
+    if(_parseSettings.getWatchFileData() && path == _parseSettings.getPath())
     {
-        emit fileChanged();
+        emit fileDataChanged();
     }
 }
 

--- a/src/datafileparser.h
+++ b/src/datafileparser.h
@@ -21,10 +21,11 @@ public:
     bool parseData(QList<QList<double> > &dataRows, QStringList &labels);
 
 signals:
-    void fileChanged();
+    void fileDataChanged();
+    void addFileWatchFailed(QString);
 
 private slots:
-    void fileChange(QString);
+    void fileDataChange(QString);
 
 private:
 

--- a/src/dataparsersettings.cpp
+++ b/src/dataparsersettings.cpp
@@ -58,6 +58,10 @@ bool DataParserSettings::getDynamicSession()
     return _bDynamicSession;
 }
 
+bool DataParserSettings::getWatchFileData()
+{
+    return _bWatchFileData;
+}
 
 
 
@@ -96,10 +100,18 @@ void DataParserSettings::setLabelRow(quint32 labelRow)
     _labelRow = labelRow;
 }
 
-void DataParserSettings::setDynamicSession(quint32 bDynamicSession)
+void DataParserSettings::setDynamicSession(bool bDynamicSession)
 {
     _bDynamicSession = bDynamicSession;
 
     emit dynamicSessionChanged(_bDynamicSession);
 }
 
+void DataParserSettings::setWatchFileData(bool bWatchFileData)
+{
+    if(_bWatchFileData != bWatchFileData)
+    {
+        _bWatchFileData = bWatchFileData;
+        emit watchFileDataChanged(_bWatchFileData);
+    }
+}

--- a/src/dataparsersettings.h
+++ b/src/dataparsersettings.h
@@ -21,6 +21,7 @@ public:
     quint32 getColumn();
     quint32 getLabelRow();
     bool getDynamicSession();
+    bool getWatchFileData();
 
     void setPath(QString path);
     void setFieldSeparator(QString fieldSeparator);
@@ -29,10 +30,12 @@ public:
     void setDataRow(quint32 dataRow);
     void setColumn(quint32 column);
     void setLabelRow(quint32 labelRow);
-    void setDynamicSession(quint32 bDynamicSession);
+    void setDynamicSession(bool bDynamicSession);
+    void setWatchFileData(bool bWatchFileData);
 
 signals:
     void dynamicSessionChanged(bool);
+    void watchFileDataChanged(bool);
 
 private:
 
@@ -44,6 +47,7 @@ private:
     quint32 _column;
     quint32 _labelRow;
     bool _bDynamicSession;
+    bool _bWatchFileData;
 
 };
 

--- a/src/loadfiledialog.cpp
+++ b/src/loadfiledialog.cpp
@@ -163,6 +163,7 @@ void LoadFileDialog::done(int r)
             _pParseSettings->setDecimalSeparator(_ui->comboDecimalSeparator->itemData(_ui->comboDecimalSeparator->currentIndex()).toString());
             _pParseSettings->setGroupSeparator(_ui->comboGroupSeparator->itemData(_ui->comboGroupSeparator->currentIndex()).toString());
             _pParseSettings->setDynamicSession(_ui->checkDynamicSession->checkState() == Qt::Checked ? true : false);
+            _pParseSettings->setWatchFileData(true);
         }
 
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -31,6 +31,9 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(_ui->actionSetManualScaleXAxis, SIGNAL(triggered()), this, SLOT(showXAxisScaleDialog()));
     connect(_ui->actionSetManualScaleYAxis, SIGNAL(triggered()), this, SLOT(showYAxisScaleDialog()));
 
+    connect(_ui->actionWatchFile, SIGNAL(toggled(bool)), this, SLOT(enableWatchFileChanged(bool)));
+    connect(_ui->actionDynamicSession, SIGNAL(toggled(bool)), this, SLOT(enableDynamicSessionChanged(bool)));
+
     _pGraphShowHide = _ui->menuShowHide;
 }
 
@@ -73,7 +76,15 @@ void MainWindow::getDataFileSettings()
         // Set pointer to new parser object
         _pParser = pNewParser;
 
-        connect(_pParser, SIGNAL(fileChanged()), this, SLOT(dataFileChange()));
+        connect(_pParser, SIGNAL(fileDataChanged()), this, SLOT(fileDataChange()));
+        connect(_pParser->getDataParseSettingsPointer(), SIGNAL(watchFileDataChanged(bool)), _ui->actionWatchFile, SLOT(setChecked(bool)));
+        connect(_pParser->getDataParseSettingsPointer(), SIGNAL(dynamicSessionChanged(bool)), _ui->actionDynamicSession, SLOT(setChecked(bool)));
+        connect(_pParser, SIGNAL(addFileWatchFailed(QString)), this, SLOT(addFileWatchFail(QString)));
+
+        _ui->actionWatchFile->setEnabled(true);
+        _ui->actionWatchFile->setChecked(_pParser->getDataParseSettingsPointer()->getWatchFileData());
+        _ui->actionDynamicSession->setEnabled(true);
+        _ui->actionDynamicSession->setChecked(_pParser->getDataParseSettingsPointer()->getDynamicSession());
     }
     else // New file load failed
     {
@@ -144,32 +155,44 @@ void MainWindow::reloadDataFile()
     updateGraph(_pParser);
 }
 
-void MainWindow::dataFileChange()
+void MainWindow::fileDataChange()
 {
     static QMutex mutex;
 
-    if(mutex.tryLock())
+    if(_pParser->getDataParseSettingsPointer()->getWatchFileData())
     {
-        QFile file(_pParser->getDataParseSettingsPointer()->getPath());
-        if(file.size() > 0)
+        if(mutex.tryLock())
         {
-            if(_pParser->getDataParseSettingsPointer()->getDynamicSession())
+            QFile file(_pParser->getDataParseSettingsPointer()->getPath());
+            if(file.size() > 0)
             {
-                reloadDataFile();
-            }
-            else
-            {
-                QMessageBox::StandardButton reply;
-                reply = QMessageBox::question(this, "Data file changed", "Reload data file?", QMessageBox::Yes|QMessageBox::No);
-                if(reply == QMessageBox::Yes)
+                if(_pParser->getDataParseSettingsPointer()->getDynamicSession())
                 {
                     reloadDataFile();
                 }
+                else
+                {
+                    QMessageBox::StandardButton reply;
+                    reply = QMessageBox::question(this, "Data file changed", "Reload data file? Press cancel to disable the auto reload  function.", QMessageBox::Yes|QMessageBox::No|QMessageBox::Cancel, QMessageBox::Yes);
+                    if(reply == QMessageBox::Yes)
+                    {
+                        reloadDataFile();
+                    }
+                    else if(reply == QMessageBox::Cancel)
+                    {
+                        _pParser->getDataParseSettingsPointer()->setWatchFileData(false);
+                    }
+                }
             }
-        }
 
-        mutex.unlock();
+            mutex.unlock();
+        }
     }
+}
+
+void MainWindow::addFileWatchFail(QString path)
+{
+    QMessageBox::warning(this, "Add file watch failed", "Failed to watch \"" + path + "\". Please check your system configuration!");
 }
 
 void MainWindow::prepareImageExport()
@@ -253,5 +276,24 @@ void MainWindow::showHideGraph(bool bState)
     QAction * pAction = qobject_cast<QAction *>(QObject::sender());
 
     _pGraphViewer->showGraph(pAction->data().toInt(), bState);
+}
+
+void MainWindow::enableWatchFileChanged(bool bState)
+{
+    _ui->actionWatchFile->setChecked(bState);
+    _ui->actionDynamicSession->setEnabled(bState);
+
+    if(_pParser != NULL)
+    {
+        _pParser->getDataParseSettingsPointer()->setWatchFileData(bState);
+    }
+}
+
+void MainWindow::enableDynamicSessionChanged(bool bState)
+{
+    if(_pParser != NULL)
+    {
+        _pParser->getDataParseSettingsPointer()->setDynamicSession(bState);
+    }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -31,10 +31,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(_ui->actionSetManualScaleXAxis, SIGNAL(triggered()), this, SLOT(showXAxisScaleDialog()));
     connect(_ui->actionSetManualScaleYAxis, SIGNAL(triggered()), this, SLOT(showYAxisScaleDialog()));
 
-    _pGraphShowHide = new QMenu("Show/Hide");
-    _pGraphShowHide->setEnabled(false);
-    _ui->menuGraph->addSeparator();
-    _ui->menuGraph->addMenu(_pGraphShowHide);
+    _pGraphShowHide = _ui->menuShowHide;
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,13 +25,15 @@ private slots:
     void getDataFileSettings();
     void exitApplication();
     void reloadDataFile();
-    void dataFileChange();
+    void fileDataChange();
+    void addFileWatchFail(QString path);
     void prepareImageExport();
     void showAbout();
     void showXAxisScaleDialog();
     void showYAxisScaleDialog();
     void showHideGraph(bool bState);
-
+    void enableWatchFileChanged(bool bState);
+    void enableDynamicSessionChanged(bool bState);
 
 private:
     bool updateGraph(DataFileParser *_pDataFileParser);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -77,6 +77,9 @@
     <addaction name="actionSetManualScaleYAxis"/>
     <addaction name="separator"/>
     <addaction name="menuShowHide"/>
+    <addaction name="separator"/>
+    <addaction name="actionWatchFile"/>
+    <addaction name="actionDynamicSession"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuGraph"/>
@@ -143,6 +146,28 @@
    </property>
    <property name="text">
     <string>Set Manual scale y-axis...</string>
+   </property>
+  </action>
+  <action name="actionWatchFile">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Watch File</string>
+   </property>
+  </action>
+  <action name="actionDynamicSession">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Dynamic Session</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -62,11 +62,21 @@
     <property name="title">
      <string>Graph</string>
     </property>
+    <widget class="QMenu" name="menuShowHide">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Show/Hide</string>
+     </property>
+    </widget>
     <addaction name="actionAutoScaleXAxis"/>
     <addaction name="actionAutoScaleYAxis"/>
     <addaction name="separator"/>
     <addaction name="actionSetManualScaleXAxis"/>
     <addaction name="actionSetManualScaleYAxis"/>
+    <addaction name="separator"/>
+    <addaction name="menuShowHide"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuGraph"/>


### PR DESCRIPTION
Two commits to update the file watch feature.

The first commit moves the show/hide menu from code to the ui file. Otherwise my two menu items are in front of the show/hide menu what isn't logic to me.

The second commit adds a couple of features and improvements:
- It renames some functions to a more logical name
- You can now enable/disable the file watch feature through the menu or the message box
- You can dynamically enable/disable the dynamic session
- When the file watch fails to add the file, a message box is shown
- And of course, the menu items to enable/disable the features are added

First quick tests are successful, however, some more testing is advised. If changes to the commits are needed, just tell me :wink:.
